### PR TITLE
refactor: streamline profile components

### DIFF
--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -3,5 +3,5 @@ const year = new Date().getFullYear();
 ---
 <footer class="mt-10 mb-4 text-center text-sm text-zinc-300/80 md:my-8">
   <div class="mb-1">Built by Aozaki</div>
-  <div>©️ 2014 - {year}</div>
+  <div>©️ 2014 - <time datetime={year.toString()}>{year}</time></div>
 </footer>

--- a/src/components/Main.astro
+++ b/src/components/Main.astro
@@ -1,13 +1,9 @@
 ---
 import { Image } from 'astro:assets'
 import { Icon } from 'astro-icon/components'
-import {
-  contactLinks,
-  email,
-  hobbies,
-  professions,
-  socialLinks,
-} from '../data/profile'
+import { contactLinks, email, hobbies, professions, socialLinks } from '../data/profile'
+
+import Avatar from '../../public/images/avatar.jpg'
 ---
 
 <div
@@ -15,11 +11,9 @@ import {
 >
   <div class="mb-6 md:mb-10">
     <Image
-      class="rounded-full transition-all duration-100"
-      src="/images/avatar.webp"
+      class="w-30 rounded-full"
+      src={Avatar}
       alt="Aozaki's avatar"
-      width="120"
-      height="120"
       loading="eager"
       fetchpriority="high"
     />
@@ -29,59 +23,55 @@ import {
 
   <div>
     <p class="mb-3 break-words md:mb-8">
-      {professions.map((item, i) => (
-        <>
-          <Icon name={item.icon} class="icon" aria-hidden="true" />
-          {' '}
-          {item.text}
-          {i < professions.length - 1 && ' / '}
-        </>
-      ))}
+      {
+        professions.map((item, i) => (
+          <>
+            <Icon name={item.icon} class="icon" aria-hidden="true" /> {item.text}
+            {i < professions.length - 1 && ' / '}
+          </>
+        ))
+      }
     </p>
 
     <p class="mb-3 md:mb-8">
-      {hobbies.map((item, i) => (
-        <>
-          <Icon name={item.icon} class="icon" aria-hidden="true" />
-          {' '}
-          {item.text}
-          {i < hobbies.length - 1 && ' / '}
-        </>
-      ))}
+      {
+        hobbies.map((item, i) => (
+          <>
+            <Icon name={item.icon} class="icon" aria-hidden="true" /> {item.text}
+            {i < hobbies.length - 1 && ' / '}
+          </>
+        ))
+      }
     </p>
 
     <p>
-      {socialLinks.map((item, i) => (
-        <>
-          <Icon name={item.icon} class="icon" aria-hidden="true" />{' '}
-          <a
-            href={item.href}
-            target="_blank"
-            rel={item.rel ?? undefined}
-            class="hover:underline"
-            >{item.text}</a
-          >
-          {i < socialLinks.length - 1 && <span class="px-2"></span>}
-        </>
-      ))}
+      {
+        socialLinks.map((item, i) => (
+          <>
+            <Icon name={item.icon} class="icon" aria-hidden="true" />{' '}
+            <a href={item.href} target="_blank" rel="noopener noreferrer" class="hover:underline">
+              {item.text}
+            </a>
+            {i < socialLinks.length - 1 && <span class="px-2" />}
+          </>
+        ))
+      }
     </p>
   </div>
 
   <div class="bg-night-blue text-center">
     <p class="mt-3 md:mt-8">
-      {contactLinks.map((item, i) => (
-        <>
-          <Icon name={item.icon} class="icon" aria-hidden="true" />{' '}
-          <a
-            href={item.href}
-            target="_blank"
-            rel={item.rel ?? undefined}
-            class="hover:underline"
-            >{item.text}</a
-          >
-          {i < contactLinks.length - 1 && <span class="px-2"></span>}
-        </>
-      ))}
+      {
+        contactLinks.map((item, i) => (
+          <>
+            <Icon name={item.icon} class="icon" aria-hidden="true" />{' '}
+            <a href={item.href} target="_blank" rel="noopener noreferrer" class="hover:underline">
+              {item.text}
+            </a>
+            {i < contactLinks.length - 1 && <span class="px-2" />}
+          </>
+        ))
+      }
     </p>
 
     <p class="mt-3 md:mt-8">

--- a/src/components/Main.astro
+++ b/src/components/Main.astro
@@ -1,6 +1,13 @@
 ---
 import { Image } from 'astro:assets'
 import { Icon } from 'astro-icon/components'
+import {
+  contactLinks,
+  email,
+  hobbies,
+  professions,
+  socialLinks,
+} from '../data/profile'
 ---
 
 <div
@@ -13,6 +20,8 @@ import { Icon } from 'astro-icon/components'
       alt="Aozaki's avatar"
       width="120"
       height="120"
+      loading="eager"
+      fetchpriority="high"
     />
   </div>
 
@@ -20,69 +29,64 @@ import { Icon } from 'astro-icon/components'
 
   <div>
     <p class="mb-3 break-words md:mb-8">
-      <Icon name="fa6-solid:stethoscope" class="icon" aria-hidden="true" />
-      Doctor /
-      <Icon name="fa6-solid:heart-pulse" class="icon" aria-hidden="true" />
-      Cardiologist /
-      <Icon name="fa6-solid:graduation-cap" class="icon" aria-hidden="true" />
-      MD
+      {professions.map((item, i) => (
+        <>
+          <Icon name={item.icon} class="icon" aria-hidden="true" />
+          {' '}
+          {item.text}
+          {i < professions.length - 1 && ' / '}
+        </>
+      ))}
     </p>
 
     <p class="mb-3 md:mb-8">
-      <Icon name="fa6-solid:camera-retro" class="icon" aria-hidden="true" />
-      Photographer /
-      <Icon name="fa6-solid:headphones-simple" class="icon" aria-hidden="true" />
-      Audiophile /
-      <Icon name="fa6-solid:film" class="icon" aria-hidden="true" />
-      Cinephile
+      {hobbies.map((item, i) => (
+        <>
+          <Icon name={item.icon} class="icon" aria-hidden="true" />
+          {' '}
+          {item.text}
+          {i < hobbies.length - 1 && ' / '}
+        </>
+      ))}
     </p>
 
     <p>
-      <Icon name="fa6-solid:feather-pointed" class="icon" aria-hidden="true" />
-      <a href="https://blog.aozaki.cc/" class="hover:underline">My Blog</a>
-      <span class="px-2"></span>
-      <Icon name="fa6-brands:twitter" class="icon" aria-hidden="true" />
-      <a href="https://310.im/x" target="_blank" rel="noopener noreferrer" class="hover:underline"
-        >Twitter</a
-      >
-      <span class="px-2"></span>
-      <Icon name="fa6-brands:mastodon" class="icon" aria-hidden="true" />
-      <a
-        href="https://310.im/ms"
-        target="_blank"
-        rel="me noopener noreferrer"
-        class="hover:underline">Mastodon</a
-      >
-      <span class="px-2"></span>
-      <Icon name="fa6-brands:github" class="icon" aria-hidden="true" />
-      <a href="https://310.im/gh" target="_blank" rel="noopener noreferrer" class="hover:underline"
-        >GitHub</a
-      >
+      {socialLinks.map((item, i) => (
+        <>
+          <Icon name={item.icon} class="icon" aria-hidden="true" />{' '}
+          <a
+            href={item.href}
+            target="_blank"
+            rel={item.rel ?? undefined}
+            class="hover:underline"
+            >{item.text}</a
+          >
+          {i < socialLinks.length - 1 && <span class="px-2"></span>}
+        </>
+      ))}
     </p>
   </div>
 
   <div class="bg-night-blue text-center">
     <p class="mt-3 md:mt-8">
-      <Icon name="fa6-brands:discord" class="icon" aria-hidden="true" />
-      <a
-        href="https://310.im/dc"
-        target="_blank"
-        rel="me noopener noreferrer"
-        class="hover:underline">Discord</a
-      >
-      <span class="px-2"></span>
-      <Icon name="fa6-brands:telegram" class="icon" aria-hidden="true" />
-      <a
-        href="https://310.im/tg"
-        target="_blank"
-        rel="me noopener noreferrer"
-        class="hover:underline">Telegram</a
-      >
+      {contactLinks.map((item, i) => (
+        <>
+          <Icon name={item.icon} class="icon" aria-hidden="true" />{' '}
+          <a
+            href={item.href}
+            target="_blank"
+            rel={item.rel ?? undefined}
+            class="hover:underline"
+            >{item.text}</a
+          >
+          {i < contactLinks.length - 1 && <span class="px-2"></span>}
+        </>
+      ))}
     </p>
 
     <p class="mt-3 md:mt-8">
-      <Icon name="fa6-solid:envelope" class="icon" aria-hidden="true" />
-      <a href="mailto:i@aozaki.cc" class="hover:underline">i#aozaki.cc</a>
+      <Icon name={email.icon} class="icon" aria-hidden="true" />{' '}
+      <a href={`mailto:${email.address}`} class="hover:underline">{email.display}</a>
     </p>
   </div>
 </div>

--- a/src/data/profile.ts
+++ b/src/data/profile.ts
@@ -1,24 +1,23 @@
 export interface IconText {
-  icon: string;
-  text: string;
+  icon: string
+  text: string
 }
 
 export interface SocialLink extends IconText {
-  href: string;
-  rel?: string;
+  href: string
 }
 
 export const professions: IconText[] = [
   { icon: 'fa6-solid:stethoscope', text: 'Doctor' },
   { icon: 'fa6-solid:heart-pulse', text: 'Cardiologist' },
   { icon: 'fa6-solid:graduation-cap', text: 'MD' },
-];
+]
 
 export const hobbies: IconText[] = [
   { icon: 'fa6-solid:camera-retro', text: 'Photographer' },
   { icon: 'fa6-solid:headphones-simple', text: 'Audiophile' },
   { icon: 'fa6-solid:film', text: 'Cinephile' },
-];
+]
 
 export const socialLinks: SocialLink[] = [
   { icon: 'fa6-solid:feather-pointed', text: 'My Blog', href: 'https://blog.aozaki.cc/' },
@@ -26,39 +25,34 @@ export const socialLinks: SocialLink[] = [
     icon: 'fa6-brands:twitter',
     text: 'Twitter',
     href: 'https://310.im/x',
-    rel: 'noopener noreferrer',
   },
   {
     icon: 'fa6-brands:mastodon',
     text: 'Mastodon',
     href: 'https://310.im/ms',
-    rel: 'me noopener noreferrer',
   },
   {
     icon: 'fa6-brands:github',
     text: 'GitHub',
     href: 'https://310.im/gh',
-    rel: 'noopener noreferrer',
   },
-];
+]
 
 export const contactLinks: SocialLink[] = [
   {
     icon: 'fa6-brands:discord',
     text: 'Discord',
     href: 'https://310.im/dc',
-    rel: 'me noopener noreferrer',
   },
   {
     icon: 'fa6-brands:telegram',
     text: 'Telegram',
     href: 'https://310.im/tg',
-    rel: 'me noopener noreferrer',
   },
-];
+]
 
 export const email = {
   icon: 'fa6-solid:envelope',
   address: 'i@aozaki.cc',
   display: 'i#aozaki.cc',
-};
+}

--- a/src/data/profile.ts
+++ b/src/data/profile.ts
@@ -1,0 +1,64 @@
+export interface IconText {
+  icon: string;
+  text: string;
+}
+
+export interface SocialLink extends IconText {
+  href: string;
+  rel?: string;
+}
+
+export const professions: IconText[] = [
+  { icon: 'fa6-solid:stethoscope', text: 'Doctor' },
+  { icon: 'fa6-solid:heart-pulse', text: 'Cardiologist' },
+  { icon: 'fa6-solid:graduation-cap', text: 'MD' },
+];
+
+export const hobbies: IconText[] = [
+  { icon: 'fa6-solid:camera-retro', text: 'Photographer' },
+  { icon: 'fa6-solid:headphones-simple', text: 'Audiophile' },
+  { icon: 'fa6-solid:film', text: 'Cinephile' },
+];
+
+export const socialLinks: SocialLink[] = [
+  { icon: 'fa6-solid:feather-pointed', text: 'My Blog', href: 'https://blog.aozaki.cc/' },
+  {
+    icon: 'fa6-brands:twitter',
+    text: 'Twitter',
+    href: 'https://310.im/x',
+    rel: 'noopener noreferrer',
+  },
+  {
+    icon: 'fa6-brands:mastodon',
+    text: 'Mastodon',
+    href: 'https://310.im/ms',
+    rel: 'me noopener noreferrer',
+  },
+  {
+    icon: 'fa6-brands:github',
+    text: 'GitHub',
+    href: 'https://310.im/gh',
+    rel: 'noopener noreferrer',
+  },
+];
+
+export const contactLinks: SocialLink[] = [
+  {
+    icon: 'fa6-brands:discord',
+    text: 'Discord',
+    href: 'https://310.im/dc',
+    rel: 'me noopener noreferrer',
+  },
+  {
+    icon: 'fa6-brands:telegram',
+    text: 'Telegram',
+    href: 'https://310.im/tg',
+    rel: 'me noopener noreferrer',
+  },
+];
+
+export const email = {
+  icon: 'fa6-solid:envelope',
+  address: 'i@aozaki.cc',
+  display: 'i#aozaki.cc',
+};

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -32,13 +32,17 @@ import '../styles/global.css'
     <!-- Font -->
     <Font cssVariable="--font-overpass" preload />
 
-    <script is:inline async src="https://sight.aozaki.cc/app.js" data-domain="aozaki.cc"></script>
+    <script is:inline>
+      window.addEventListener('load', () => {
+        const script = document.createElement('script')
+        script.src = 'https://sight.aozaki.cc/app.js'
+        script.dataset.domain = 'aozaki.cc'
+        document.head.appendChild(script)
+      })
+    </script>
   </head>
   <body
-    class="bg-[#111729] box-border flex min-h-[100dvh] flex-col tracking-tight antialiased selection:bg-sky-600/20 md:tracking-normal
-         [background-image:radial-gradient(#e2c48d6c_1%,transparent_0),radial-gradient(#e2c48d6c_1%,transparent_0)]
-         [background-size:80px_80px]
-         [background-position:0_0,160px_160px] font-sans"
+    class="box-border flex min-h-[100dvh] flex-col bg-[#111729] [background-image:radial-gradient(#e2c48d6c_1%,transparent_0),radial-gradient(#e2c48d6c_1%,transparent_0)] [background-size:80px_80px] [background-position:0_0,160px_160px] font-sans tracking-tight antialiased selection:bg-sky-600/20 md:tracking-normal"
   >
     <slot />
   </body>


### PR DESCRIPTION
## Summary
- centralize profile links and icons
- reuse data to generate profile sections and prioritize avatar loading
- delay analytics script until after page load to avoid competing network requests

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_688ec76bc7e88331b3232468dbfab2c3